### PR TITLE
Foundry V12 support, and Hexagonal columns - Odd

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -39,6 +39,7 @@
         "ShowTravelTool": "Show Travel Overlay",
         "ChexTools": "Chex",
         "EnableChex": "Add/Remove Chex to current Scene",
+        "RealmSelector": "Realm Selector",
         "Settings": "Settings",
         "TerrainSelector": "Terrain Palette"
       },

--- a/module.json
+++ b/module.json
@@ -5,11 +5,11 @@
     "authors": [
       { "name": "cedi" }
     ],
-    "version": "1.0.2",
+    "version": "2.0.0",
     "compatibility": {
-      "minimum": "11.315",
-      "verified": "11.315",
-      "maximum": "11"
+      "minimum": "12.331",
+      "verified": "12.331",
+      "maximum": "12"
     },
     "esmodules": [
       "scripts/main.mjs"

--- a/scripts/chex-data.mjs
+++ b/scripts/chex-data.mjs
@@ -1,6 +1,12 @@
+import ChexOffset from "./chex-offset.mjs";
+
 export default class ChexData {
+     /**
+     * The key used to store data on this hex
+     * @type {ChexOffset}
+     */
     static getKey(offset) {
-        return (1000 * offset.row) + offset.col;
+        return (1000 * offset.i) + offset.j;
     }
 
     /**

--- a/scripts/chex-drawing-layer.mjs
+++ b/scripts/chex-drawing-layer.mjs
@@ -118,7 +118,7 @@ export default class ChexDrawingLayer extends PIXI.Container {
    * @returns {Array<{outer: PIXI.Polygon, holes: PIXI.Polygon[]}>}
    */
   static #buildPolygons(hexes) {
-    const g = canvas.grid.grid;
+    const g = canvas.grid;
     const c = new ClipperLib.Clipper();
     let polyTree = new ClipperLib.PolyTree();
 

--- a/scripts/chex-drawing-layer.mjs
+++ b/scripts/chex-drawing-layer.mjs
@@ -126,7 +126,7 @@ export default class ChexDrawingLayer extends PIXI.Container {
     c.AddPath([], ClipperLib.PolyType.ptSubject, true);
     for ( const hex of hexes ) {
       const {x, y} = hex.topLeft;
-      const p = new PIXI.Polygon(g.getPolygon(x, y, g.w, Math.ceil(g.h)+1));
+      const p = new PIXI.Polygon(g.getVertices(hex.offset));
       c.AddPath(p.toClipperPoints(), ClipperLib.PolyType.ptClip, true);
     }
     c.Execute(ClipperLib.ClipType.ctUnion, polyTree, ClipperLib.PolyFillType.pftEvenOdd, ClipperLib.PolyFillType.pftNonZero);

--- a/scripts/chex-hud.mjs
+++ b/scripts/chex-hud.mjs
@@ -169,10 +169,10 @@ export default class ChexHexHUD extends Application {
 
       if ( this.enabled ) {
         let {x, y} = hex.topLeft;
-        const options = {left: x + hex.config.width + 20, top: y};
+        const options = {left: x + hex.grid.sizeX + 20, top: y};
         // Highlights this hex  
-        canvas.grid.clearHighlightLayer(C.HIGHLIGHT_LAYER);
-        canvas.grid.highlightPosition(C.HIGHLIGHT_LAYER, {x, y, color: Color.from(hex.color)});
+        canvas.interface.grid.clearHighlightLayer(C.HIGHLIGHT_LAYER);
+        canvas.interface.grid.highlightPosition(C.HIGHLIGHT_LAYER, {x, y, color: Color.from(hex.color)});
 
         if (chex.manager.pendingPatches.length > 0) {
           chex.manager.pendingPatches.forEach(patch => {
@@ -183,7 +183,7 @@ export default class ChexHexHUD extends Application {
             else if (patch.patch.claimed)
               color = chex.realms[patch.patch.claimed]?.color || C.FALLBACK_COLOR;
 
-            canvas.grid.highlightPosition(C.HIGHLIGHT_LAYER, {x, y, color: Color.from(color)});
+            canvas.interface.grid.highlightPosition(C.HIGHLIGHT_LAYER, {x, y, color: Color.from(color)});
           });
         }
 
@@ -198,7 +198,7 @@ export default class ChexHexHUD extends Application {
      */
     clear() {
       let states = this.constructor.RENDER_STATES;
-      canvas.grid.clearHighlightLayer(C.HIGHLIGHT_LAYER);
+      canvas.interface.grid.clearHighlightLayer(C.HIGHLIGHT_LAYER);
       if ( this._state <= states.NONE ) return;
       this._state = states.CLOSING;
       this.element.hide();

--- a/scripts/chex-offset.mjs
+++ b/scripts/chex-offset.mjs
@@ -1,0 +1,11 @@
+// Implements foundry.GridOffset
+// https://foundryvtt.com/api/interfaces/foundry.GridOffset.html
+// Created as a mapping from the Typescript interface to a concrete class
+export default class ChexOffset {
+    i;
+    j;
+    constructor(i, j) {
+        this.i = i;
+        this.j = j;
+    }
+}

--- a/scripts/hex.mjs
+++ b/scripts/hex.mjs
@@ -4,9 +4,10 @@ import { Travel } from "./customizables/travel.mjs";
 import ChexData from "./chex-data.mjs";
 import ChexSceneData from "./scene-data.mjs";
 
-export default class ChexHex extends GridHex {
-    constructor(offset, config, sceneId) {
-        super(offset, config);
+export default class ChexHex extends foundry.grid.GridHex {
+
+    constructor(coordinates, grid, sceneId) {
+        super(coordinates, grid);
         this.sceneId = sceneId;
     }
 
@@ -65,6 +66,6 @@ export default class ChexHex extends GridHex {
     }
 
     toString() {
-        return `${this.offset.row}.${this.offset.col}`;
+        return `${this.offset.i}.${this.offset.j}`;
     }
 }

--- a/scripts/manager.mjs
+++ b/scripts/manager.mjs
@@ -368,7 +368,7 @@ export default class ChexManager {
     }
 
     getHexFromPoint(point) {
-		const {i, j} = canvas.grid.getOffset(point.x, point.y);
+		const {i, j} = canvas.grid.getOffset(point);
 		return this.hexes.get(ChexData.getKey({i, j}));
 	}
 

--- a/scripts/manager.mjs
+++ b/scripts/manager.mjs
@@ -182,7 +182,7 @@ export default class ChexManager {
     }
 
     get isValidGrid() {
-        return canvas.grid.type === 2;
+        return canvas.grid.type === foundry.CONST.GRID_TYPES.HEXODDR || canvas.grid.type === foundry.CONST.GRID_TYPES.HEXODDQ;
     }
 
     #showSettings() {
@@ -210,7 +210,7 @@ export default class ChexManager {
             }
             else {
                 // message that it wont work with other grids currently
-                ui.notifications.warn("Currently, Chex only works for Hexagonal Rows - Odd");
+                ui.notifications.warn("Currently, Chex only works for Hexagonal Rows - Odd, or Hexagonal Columns - Odd");
             }
         }
 

--- a/scripts/manager.mjs
+++ b/scripts/manager.mjs
@@ -372,33 +372,4 @@ export default class ChexManager {
 		return this.hexes.get(ChexData.getKey({i, j}));
 	}
 
-      /**
-   * Compute the offset coordinate of a hexagon from a pixel coordinate contained within that hex.
-   * @param {Point} point                     The pixel coordinate
-   * @param {HexGridConfiguration} config     The hex grid configuration
-   * @param {string} [method=floor]           Which Math rounding method to use
-   * @returns {HexOffsetCoordinate}           The offset coordinate
-   */
-  pixelsToOffset({x, y}, config, method="floor") {
-    const {columns, even, width, height} = config;
-    const fn = Math[method];
-    let row;
-    let col;
-
-    // Columnar orientation
-    if ( columns ) {
-      col = fn(x / (width * 0.866));
-      const isEven = (col + 1) % 2 === 0;
-      row = fn((y / height) + (even === isEven ? 0.5 : 0));
-    }
-
-    // Row orientation
-    else {
-      row = fn(y / (height * 0.866));
-      const isEven = (row + 1) % 2 === 0;
-      col = fn((x / width) + (even === isEven ? 0.5 : 0));
-    }
-    return {row, col};
-  }
-
 }

--- a/scripts/manager.mjs
+++ b/scripts/manager.mjs
@@ -10,6 +10,7 @@ import ChexHexHUD from "./chex-hud.mjs";
 import ChexHex from "./hex.mjs";
 import ChexDrawingLayer from "./chex-drawing-layer.mjs";
 import ChexSceneData from "./scene-data.mjs";
+import ChexOffset from "./chex-offset.mjs";
 import CHexData from "./scene-data.mjs";
 
 export default class ChexManager {
@@ -42,12 +43,13 @@ export default class ChexManager {
         if (!this.active) return;
         this.hexes = new Collection();
         const data = this.sceneData;
-        const config = HexagonalGrid.getConfig(data.type, data.size);
+        const grid = canvas.scene.grid;
 
         for (let row = 0; row < data.numRows; row++) {
             for (let col = 0; col < data.numCols; col++) {
-                const hex = new ChexHex({row, col}, config, data.sceneId)
-                this.hexes.set(ChexData.getKey({row, col}), hex);
+                const offset = new ChexOffset(row, col);
+                const hex = new ChexHex(offset, grid, data.sceneId)
+                this.hexes.set(ChexData.getKey(offset), hex);
             }
         }
     }
@@ -237,10 +239,10 @@ export default class ChexManager {
             if (canvas.scene.tokenVision)
                 canvas.stage.rendered.environment.effects.addChildAt(chex.manager.kingdomLayer, 1);
             else 
-                canvas.grid.addChildAt(this.kingdomLayer, canvas.grid.children.indexOf(canvas.grid.borders));
+                canvas.interface.grid.addChild(this.kingdomLayer);
         }
         this.kingdomLayer.draw();
-        canvas.grid.addHighlightLayer(C.HIGHLIGHT_LAYER);
+        canvas.interface.grid.addHighlightLayer(C.HIGHLIGHT_LAYER);
 
         this.#mousemove = this.#onMouseMove.bind(this);
         canvas.stage.on("mousemove", this.#mousemove);
@@ -263,7 +265,7 @@ export default class ChexManager {
         canvas.stage.off(this.#mousedown);
         this.#mousedown = undefined;
 
-        canvas.grid.destroyHighlightLayer(C.HIGHLIGHT_LAYER);
+        canvas.interface.grid.destroyHighlightLayer(C.HIGHLIGHT_LAYER);
         this.kingdomLayer = undefined;
         this.hud.enabled = false;
     }
@@ -366,9 +368,8 @@ export default class ChexManager {
     }
 
     getHexFromPoint(point) {
-        const grid = canvas.grid.grid;
-		const [row, col] = canvas.grid.grid.getGridPositionFromPixels(point.x, point.y);
-		return this.hexes.get(ChexData.getKey({row, col}));
+		const {i, j} = canvas.grid.getOffset(point.x, point.y);
+		return this.hexes.get(ChexData.getKey({i, j}));
 	}
 
       /**

--- a/scripts/scene-data.mjs
+++ b/scripts/scene-data.mjs
@@ -22,12 +22,17 @@ export default class ChexSceneData {
         data.size = scene.grid.size;
         data.width = dimensions.width;
         data.height = dimensions.height;
-        // Hexagonal Rows - Odd (type 2)
-        // since the pointy part points up, 
-        data.numRows = Math.ceil(data.height / (0.866 * data.size)); // sqrt(3)/2 * size is the formula for a tightly packed hexgrid
-        data.numCols = Math.ceil(data.width / data.size);
-
-        const config = HexagonalGrid.getConfig(data.type, data.size);
+        if (scene.grid.type === foundry.CONST.GRID_TYPES.HEXODDR) {
+            // Hexagonal Rows - Odd (type 2)
+            // since the pointy part points up, 
+            data.numRows = Math.ceil(data.height / (0.866 * data.size)); // sqrt(3)/2 * size is the formula for a tightly packed hexgrid
+            data.numCols = Math.ceil(data.width / data.size);
+        } else {
+            // Hexagonal Columns - Odd
+            // cols are now applied the formula instead.
+            data.numRows = Math.ceil(data.height / data.size);
+            data.numCols = Math.ceil(data.width / (0.866 * data.size)); // sqrt(3)/2 * size is the formula for a tightly packed hexgrid
+        }
 
         data.hexes = {};
         for (let row = 0; row < data.numRows; row++) {

--- a/scripts/scene-data.mjs
+++ b/scripts/scene-data.mjs
@@ -1,5 +1,6 @@
 import * as C from "./const.mjs";
 import ChexData from "./chex-data.mjs";
+import ChexOffset from "./chex-offset.mjs";
 
 export default class ChexSceneData {
     hexes = {};
@@ -32,7 +33,8 @@ export default class ChexSceneData {
         for (let row = 0; row < data.numRows; row++) {
             for (let col = 0; col < data.numCols; col++) {
                 const hex = new ChexData();
-                let key = ChexData.getKey({row, col});
+                const offset = new ChexOffset(row, col);
+                let key = ChexData.getKey(offset);
                 data.hexes[key] = hex;
             }
         }

--- a/templates/chex-customizer.hbs
+++ b/templates/chex-customizer.hbs
@@ -34,7 +34,7 @@
 
     <fieldset name="chex-realms">
         <legend>
-            {{localize 'CHEX.CUSOMIZER.Realms'}}
+            {{localize 'CHEX.CUSTOMIZER.Realms'}}
             <button type="button" data-action="addRealm" class="chex-add-button">
                 <span>{{localize 'CHEX.HEXEDIT.Add'}}</span>
             </button>

--- a/templates/chex-edit.hbs
+++ b/templates/chex-edit.hbs
@@ -5,7 +5,7 @@
             <label data-tooltip="CHEX.HEXEDIT.ExplorationTooltip">{{localize 'CHEX.HEXEDIT.Exploration'}}</label>
             <div class="form-fields">
                 <select name="exploration">
-                    {{selectOptions explorationStates selected=hex.exploration nameAttr="value" labelAttr="label" localize=true }}
+                    {{selectOptions explorationStates selected=hex.exploration valueAttr="value" labelAttr="label" localize=true }}
                 </select>
             </div>
         </div>
@@ -19,7 +19,7 @@
             <label data-tooltip="CHEX.HEXEDIT.ClaimedTooltip">{{localize 'CHEX.HEXEDIT.Claimed'}}</label>
             <div class="form-fields">
                 <select name="claimed">
-                    {{selectOptions claimees selected=hex.claimed nameAttr="id" labelAttr="label" blank=""}}
+                    {{selectOptions claimees selected=hex.claimed valueAttr="id" labelAttr="label" blank=""}}
                 </select>
             </div>
         </div>

--- a/templates/chex-realm-selector.hbs
+++ b/templates/chex-realm-selector.hbs
@@ -1,6 +1,6 @@
 <div>
     <select class="chex-realm-select" id="chex-realm-select" name="realms">
-        {{selectOptions realms nameAttr="id" labelAttr="label" blank=""}}
+        {{selectOptions realms valueAttr="id" labelAttr="label" blank=""}}
     </select>
     <button data-action="report">
         {{localize "CHEX.REALMSELECTOR.IncomeReport"}}

--- a/templates/frags/chex-features.hbs
+++ b/templates/frags/chex-features.hbs
@@ -1,6 +1,6 @@
 <div class="form-group">
     <select name="features.{{id}}.id">
-        {{selectOptions features selected=key nameAttr="id" labelAttr="label" blank=""}}
+        {{selectOptions features selected=key valueAttr="id" labelAttr="label" blank=""}}
     </select>
     <input type="text" data-tooltip="CHEX.HEXEDIT.Name" name="features.{{id}}.name" value="{{name}}">
     <input type="checkbox" data-tooltip="CHEX.HEXEDIT.ShowToPlayersTooltip" name="features.{{id}}.show" {{checked show}}>

--- a/templates/frags/chex-forageables.hbs
+++ b/templates/frags/chex-forageables.hbs
@@ -1,6 +1,6 @@
 <div class="form-group">
     <select name="forageables.{{id}}.id">
-        {{selectOptions forageables selected=key nameAttr="id" labelAttr="label" blank=""}}
+        {{selectOptions forageables selected=key valueAttr="id" labelAttr="label" blank=""}}
     </select>
     <input type="number" data-tooltip="CHEX.HEXEDIT.Amount" name="forageables.{{id}}.amount" value="{{amount}}">
     <input type="checkbox" data-tooltip="CHEX.HEXEDIT.ShowToPlayersTooltip" name="forageables.{{id}}.show" {{checked show}}>

--- a/templates/frags/chex-improvements.hbs
+++ b/templates/frags/chex-improvements.hbs
@@ -1,6 +1,6 @@
 <div class="form-group">
     <select name="improvements.{{id}}.id">
-        {{selectOptions improvements selected=key nameAttr="id" labelAttr="label" blank=""}}
+        {{selectOptions improvements selected=key valueAttr="id" labelAttr="label" blank=""}}
     </select>
     <input type="checkbox" data-tooltip="CHEX.HEXEDIT.ShowToPlayersTooltip" name="improvements.{{id}}.show" {{checked show}}>
     <button data-tooltip="CHEX.HEXEDIT.Delete" type="button" class="fa-solid fa-times chex-delete" data-action="delete"/>

--- a/templates/frags/chex-resources.hbs
+++ b/templates/frags/chex-resources.hbs
@@ -1,6 +1,6 @@
 <div class="form-group">
     <select name="resources.{{id}}.id">
-        {{selectOptions resources selected=key nameAttr="id" labelAttr="label" blank=""}}
+        {{selectOptions resources selected=key valueAttr="id" labelAttr="label" blank=""}}
     </select>
     <input type="number" data-tooltip="CHEX.HEXEDIT.Amount" name="resources.{{id}}.amount" value="{{amount}}">
     <input type="checkbox" data-tooltip="CHEX.HEXEDIT.ShowToPlayersTooltip" name="resources.{{id}}.show" {{checked show}}>


### PR DESCRIPTION
**Changes in brief**

* V12 support added, did not maintain compatibility 
* Support for Hexagonal Odd Columns.
* Some missing strings added or corrected.
* Major Version increase as this is currently a breaking change. If you want to take my changes and make a different MR where that is not the case, feel free to do so.

**Description**

A bit of work would probably let there be a compatibility here for 11 or 12, but I didn't bother. Seems to be working on my V12. If there is anything more you want me to test, please let me know.

In addition, since I only had an odd Hexagonal column map sitting around, I added support for that map type as well. I suspect with the changes to the draw layer, if we spent a bit more time on `scene-data.mjs` it would be possible to support all hex grid types. I don't have your old supported hex grid laying around, so I hope I didn't break it.

I also found a couple of string issues.

I see no warnings or errors when using this version, but its possible I missed functionality I don't know about, or haven't set up yet.

**Supporting Images**

Travel Layer working

![TravelLayer](https://github.com/user-attachments/assets/0c9867fb-d15b-4de9-8c69-7c5e07e2344d)

Terrain Painter Working, showing various types

![TerrainPainterOfVariousTypes](https://github.com/user-attachments/assets/715c0f4d-5afc-4376-92f6-64aca51d73b5)

Customized Kingdom Claimed + some Terrain Data

![KingdomWithTerrainData](https://github.com/user-attachments/assets/976d5325-6b6d-41ae-aab1-c621a4dc86d5)

