### PR TITLE
v13 basic compatibility

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -41,7 +41,8 @@
         "EnableChex": "Add/Remove Chex to current Scene",
         "RealmSelector": "Realm Selector",
         "Settings": "Settings",
-        "TerrainSelector": "Terrain Palette"
+        "TerrainSelector": "Terrain Palette",
+        "Dummy": "This button prevents an error by existing"
       },
       "CUSTOMIZER": {
         "Title": "Chex Customizer",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -41,7 +41,8 @@
         "EnableChex": "Dodaj/usuń Chex do bieżącej sceny",
         "RealmSelector": "Selektor Krain",
         "Settings": "Ustawienia",
-        "TerrainSelector": "Paleta terenu"
+        "TerrainSelector": "Paleta terenu",
+        "Dummy":"Zapobiega to wystąpieniu błędu"
       },
       "CUSTOMIZER": {
         "Title": "Dostosowywanie Chex",

--- a/module.json
+++ b/module.json
@@ -5,11 +5,11 @@
     "authors": [
       { "name": "cedi" }
     ],
-    "version": "2.0.0",
+    "version": "3.0.0",
     "compatibility": {
-      "minimum": "12.331",
-      "verified": "12.331",
-      "maximum": "12"
+      "minimum": "13.344",
+      "verified": "13.345",
+      "maximum": "13"
     },
     "esmodules": [
       "scripts/main.mjs"
@@ -28,8 +28,8 @@
       }
     ],
     "protected": false,
-    "url": "https://github.com/MeusRex/pf2e-chex",
-    "download": "https://github.com/MeusRex/pf2e-chex/archive/refs/tags/chex-v2.0.0.zip",
-    "manifest": "https://raw.githubusercontent.com/meusrex/pf2e-chex/main/module.json"
+    "url": "https://github.com/RicoTheBold/pf2e-chex",
+    "download": "https://github.com/RicoTheBold/pf2e-chex/archive/refs/tags/chex-v3.0.0.zip",
+    "manifest": "https://raw.githubusercontent.com/ricothebold/pf2e-chex/main/module.json"
   }
   

--- a/module.json
+++ b/module.json
@@ -28,8 +28,8 @@
       }
     ],
     "protected": false,
-    "url": "https://github.com/RicoTheBold/pf2e-chex",
-    "download": "https://github.com/RicoTheBold/pf2e-chex/archive/refs/tags/chex-v3.0.0.zip",
-    "manifest": "https://raw.githubusercontent.com/ricothebold/pf2e-chex/main/module.json"
+    "url": "https://github.com/MeusRex/pf2e-chex",
+    "download": "https://github.com/MeusRex/pf2e-chex/archive/refs/tags/chex-v3.0.0.zip",
+    "manifest": "https://raw.githubusercontent.com/meusrex/pf2e-chex/main/module.json"
   }
   

--- a/scripts/customizables/terrain.mjs
+++ b/scripts/customizables/terrain.mjs
@@ -23,7 +23,7 @@ export class Terrain {
             mountains: new Terrain("mountains", "Mountains", "icons/environment/wilderness/cave-entrance-mountain-blue.webp", "fa-solid fa-mountain", "greater", "#696969"),
             wetlands: new Terrain("wetlands", "Wetlands", "icons/environment/settlement/bridge-stone.webp", "fa-solid fa-bath", "difficult", "#ee82ee"),
             swamp: new Terrain("swamp", "Swamp", "icons/magic/nature/tree-spirit-black.webp", "fa-solid fa-bug", "greater", "#663399"),
-            water: new Terrain("water", "Water", "icons/environment/wilderness/island.webp", "fa-solid fa-tint", "water", "0000ff"),
+            water: new Terrain("water", "Water", "icons/environment/wilderness/island.webp", "fa-solid fa-tint", "water", "#0000ff"),
             desert: new Terrain("desert", "Desert", "icons/environment/wilderness/cave-entrance-rocky.webp", "fa-solid fa-sun", "open", "#ffff00")
         };
     }

--- a/scripts/main.mjs
+++ b/scripts/main.mjs
@@ -121,5 +121,5 @@ Hooks.once("setup", function() {
 Hooks.on("canvasReady", () => chex.manager._onReady());
 Hooks.on("canvasTearDown", () => chex.manager._onTearDown());
 Hooks.on("canvasInit", () => chex.manager._onInit());
-Hooks.on("getSceneControlButtons", buttons => chex.manager._extendSceneControlButtons(buttons));
+Hooks.on("getSceneControlButtons", controls => chex.manager._extendSceneControlButtons(controls));
 Hooks.on("updateScene", (document, change) => chex.manager._updateScene(document, change));

--- a/scripts/realm-palette.mjs
+++ b/scripts/realm-palette.mjs
@@ -20,7 +20,7 @@ export default class RealmPalette extends FormApplication {
     return  game.i18n.localize("CHEX.REALMSELECTOR.Title");
   }
 
-  get activeTool() {
+  get activeRealmTool() {
     const selectElement = document.getElementById('chex-realm-select');
     return selectElement.options[selectElement.selectedIndex].value;
   }
@@ -51,14 +51,14 @@ export default class RealmPalette extends FormApplication {
     const control = event.currentTarget;
     const action = control.dataset.action;
     
-    if (action === "report" && this.activeTool) {
-      const realm = this.activeTool;
+    if (action === "report" && this.activeRealmTool) {
+      const realm = this.activeRealmTool;
       let hexes = Object.values(canvas.scene.getFlag(MODULE_ID, CHEX_DATA_KEY).hexes);
       let mergedResources = {};
 
       // Iterate over each hexData and sum up the resources
       hexes.forEach((hexData) => {
-        if (hexData.claimed === this.activeTool) {
+        if (hexData.claimed === this.activeRealmTool) {
 
           const resources = ChexFormulaParser.getResources(hexData);
           if (Object.keys(resources)) {

--- a/scripts/terrain-palette.mjs
+++ b/scripts/terrain-palette.mjs
@@ -17,7 +17,7 @@ export default class TerrainPalette extends FormApplication {
     return  game.i18n.localize("CHEX.TERRAINSELECTOR.Title");
   }
 
-  activeTool = null;
+  activeTerrainTool = null;
 
   async _render(force, options) {
     chex.terrainSelector = this;
@@ -44,7 +44,7 @@ export default class TerrainPalette extends FormApplication {
     event.preventDefault();
     const control = event.currentTarget;
     const action = control.dataset.action;
-    this.activeTool = action;
+    this.activeTerrainTool = action;
 
     const form = document.getElementById(TerrainPalette.formId);
     const buttons = form.querySelectorAll('button');

--- a/styles/chex.css
+++ b/styles/chex.css
@@ -70,8 +70,12 @@
 
 
 .chex-delete {
-  max-width: 27px;
-  min-height: 27px;
+  max-width: 24px;
+  max-height: 24px;
+  line-height: 22px;
+  align-items: center;
+  vertical-align: middle;
+  padding: 0px 0px 0px 3px;
 }
 
 .chex-add-button {
@@ -82,7 +86,12 @@
 }
 
 .chex-open-filepicker {
-  width: fit-content;
+  max-width: 24px;
+  max-height: 24px;
+  line-height: 22px;
+  align-items: center;
+  vertical-align: middle;
+  padding: 0px 0px 0px 3px;
 }
 
 .chex-flex {
@@ -139,8 +148,9 @@
 
 /* Style for each button */
 .chex-terrain-selector button {
-  margin-bottom: 5px; /* Adjust the margin as needed */
+  margin-bottom: 4px; /* Adjust the margin as needed */
   width: 30px;
+  padding: 0px 0px 0px 4px;
 }
 
 .chex-terrain-selector button.active {

--- a/templates/chex-terrain-selector.hbs
+++ b/templates/chex-terrain-selector.hbs
@@ -1,5 +1,5 @@
 <div class="chex-terrain-selector">
     {{#each terrains}}
-        <button id="{{id}}" data-tooltip="{{label}}" class="{{toolIcon}}" data-action="{{id}}"></button>
+        <button id="{{id}}" data-tooltip="{{label}}" data-action="{{id}}"> <i class="{{toolIcon}}"> </i></button>
     {{/each}}
 </div>

--- a/templates/frags/chex-custom-features.hbs
+++ b/templates/frags/chex-custom-features.hbs
@@ -1,7 +1,7 @@
 {{#with feature}}
     <div class="chex-grid-container">
         <!-- First Row -->
-        <button data-tooltip="CHEX.HEXEDIT.Delete" type="button" class="fa-solid fa-times chex-delete" data-action="delete"></button>
+        <button data-tooltip="CHEX.HEXEDIT.Delete" type="button" class="chex-delete" data-action="delete"><i class="fa-solid fa-times"></i></button>
         <div class="chex-item-container">
             <p class="chex-item">
                 <span data-tooltip="CHEX.CUSTOMIZER.IdTT" class="chex-key">{{localize "CHEX.CUSTOMIZER.Id"}}</span>
@@ -14,7 +14,7 @@
             <p class="chex-item">
                 <span class="chex-key">{{localize "CHEX.CUSTOMIZER.Image"}}</span>
                 <input class="chex-icon-path" type="text" name="features.{{id}}.img" value="{{this.img}}">
-                <button data-tooltip="CHEX.CUSTOMIZER.PickIconTT" class="fa-solid fa-image chex-open-filepicker" data-action="pickIcon"></button>
+                <button data-tooltip="CHEX.CUSTOMIZER.PickIconTT" class="chex-open-filepicker" data-action="pickIcon"><i class="fa-solid fa-image"></i></button>
             </p>
         </div>
         <img class="chex-img-preview" src="{{this.img}}" alt="Image Preview">

--- a/templates/frags/chex-custom-improvements.hbs
+++ b/templates/frags/chex-custom-improvements.hbs
@@ -1,7 +1,7 @@
 {{#with improvement}}
     <div class="chex-grid-container">
         <!-- First Row -->
-        <button data-tooltip="CHEX.HEXEDIT.Delete" type="button" class="fa-solid fa-times chex-delete" data-action="delete"></button>
+        <button data-tooltip="CHEX.HEXEDIT.Delete" type="button" class="chex-delete" data-action="delete"><i class="fa-solid fa-times"></i></button>
         <div class="chex-item-container">
             <p class="chex-item">
                 <span data-tooltip="CHEX.CUSTOMIZER.IdTT" class="chex-key">{{localize "CHEX.CUSTOMIZER.Id"}}</span>
@@ -14,7 +14,7 @@
             <p class="chex-item">
                 <span class="chex-key">{{localize "CHEX.CUSTOMIZER.Image"}}</span>
                 <input class="chex-icon-path" type="text" name="improvements.{{id}}.img" value="{{this.img}}">
-                <button data-tooltip="CHEX.CUSTOMIZER.PickIconTT" class="fa-solid fa-image chex-open-filepicker" data-action="pickIcon"></button>
+                <button data-tooltip="CHEX.CUSTOMIZER.PickIconTT" class="chex-open-filepicker" data-action="pickIcon"><i class="fa-solid fa-image"></i></button>
             </p>
             <p class="chex-item">
                 <span data-tooltip="CHEX.CUSTOMIZER.FormulaTT" class="chex-key">{{localize "CHEX.CUSTOMIZER.Formula"}}</span>

--- a/templates/frags/chex-custom-realms.hbs
+++ b/templates/frags/chex-custom-realms.hbs
@@ -1,7 +1,7 @@
 {{#with realm}}
     <div class="chex-grid-container">
         <!-- First Row -->
-        <button data-tooltip="CHEX.HEXEDIT.Delete" type="button" class="fa-solid fa-times chex-delete" data-action="delete"></button>
+        <button data-tooltip="CHEX.HEXEDIT.Delete" type="button" class="chex-delete" data-action="delete"><i class="fa-solid fa-times"></i></button>
         <div class="chex-item-container">
             <p class="chex-item">
                 <span data-tooltip="CHEX.CUSTOMIZER.IdTT" class="chex-key">{{localize "CHEX.CUSTOMIZER.Id"}}</span>

--- a/templates/frags/chex-custom-resources.hbs
+++ b/templates/frags/chex-custom-resources.hbs
@@ -1,7 +1,7 @@
 {{#with resource}}
     <div class="chex-grid-container">
         <!-- First Row -->
-        <button data-tooltip="CHEX.HEXEDIT.Delete" type="button" class="fa-solid fa-times chex-delete" data-action="delete"></button>
+        <button data-tooltip="CHEX.HEXEDIT.Delete" type="button" class="chex-delete" data-action="delete"><i class="fa-solid fa-times"></i></button>
         <div class="chex-item-container">
             <p class="chex-item">
                 <span data-tooltip="CHEX.CUSTOMIZER.IdTT" class="chex-key">{{localize "CHEX.CUSTOMIZER.Id"}}</span>
@@ -14,7 +14,7 @@
             <p class="chex-item">
                 <span class="chex-key">{{localize "CHEX.CUSTOMIZER.Image"}}</span>
                 <input class="chex-icon-path" type="text" name="resources.{{id}}.img" value="{{this.img}}">
-                <button data-tooltip="CHEX.CUSTOMIZER.PickIconTT" class="fa-solid fa-image chex-open-filepicker" data-action="pickIcon"></button>
+                <button data-tooltip="CHEX.CUSTOMIZER.PickIconTT" class="chex-open-filepicker" data-action="pickIcon"><i class="fa-solid fa-image"></i></button>
             </p>
         </div>
         <img class="chex-img-preview" src="{{this.img}}" alt="Image Preview">

--- a/templates/frags/chex-custom-terrains.hbs
+++ b/templates/frags/chex-custom-terrains.hbs
@@ -1,7 +1,7 @@
 {{#with terrain}}
     <div class="chex-grid-container">
         <!-- First Row -->
-        <button data-tooltip="CHEX.HEXEDIT.Delete" type="button" class="fa-solid fa-times chex-delete" data-action="delete"></button>
+        <button data-tooltip="CHEX.HEXEDIT.Delete" type="button" class="chex-delete" data-action="delete"><i class="fa-solid fa-times"></i></button>
         <div class="chex-item-container">
             <p class="chex-item">
                 <span data-tooltip="CHEX.CUSTOMIZER.IdTT" class="chex-key">{{localize "CHEX.CUSTOMIZER.Id"}}</span>
@@ -14,7 +14,7 @@
             <p class="chex-item">
                 <span class="chex-key">{{localize "CHEX.CUSTOMIZER.Image"}}</span>
                 <input class="chex-icon-path" type="text" name="terrains.{{id}}.img" value="{{this.img}}">
-                <button data-tooltip="CHEX.CUSTOMIZER.PickIconTT" class="fa-solid fa-image chex-open-filepicker" data-action="pickIcon"></button>
+                <button data-tooltip="CHEX.CUSTOMIZER.PickIconTT" class="chex-open-filepicker" data-action="pickIcon"><i class="fa-solid fa-image"></i></button>
             </p>
             <p class="chex-item">
                 <span data-tooltip="CHEX.CUSTOMIZER.ToolIconTT" class="chex-key">{{localize "CHEX.CUSTOMIZER.ToolIcon"}}</span>

--- a/templates/frags/chex-custom-travels.hbs
+++ b/templates/frags/chex-custom-travels.hbs
@@ -1,7 +1,7 @@
 {{#with travel}}
     <div class="chex-grid-container">
         <!-- First Row -->
-        <button data-tooltip="CHEX.HEXEDIT.Delete" type="button" class="fa-solid fa-times chex-delete" data-action="delete"></button>
+        <button data-tooltip="CHEX.HEXEDIT.Delete" type="button" class="chex-delete" data-action="delete"><i class="fa-solid fa-times"></i></button>
         <div class="chex-item-container">
             <p class="chex-item">
                 <span data-tooltip="CHEX.CUSTOMIZER.IdTT" class="chex-key">{{localize "CHEX.CUSTOMIZER.Id"}}</span>

--- a/templates/frags/chex-features.hbs
+++ b/templates/frags/chex-features.hbs
@@ -4,5 +4,5 @@
     </select>
     <input type="text" data-tooltip="CHEX.HEXEDIT.Name" name="features.{{id}}.name" value="{{name}}">
     <input type="checkbox" data-tooltip="CHEX.HEXEDIT.ShowToPlayersTooltip" name="features.{{id}}.show" {{checked show}}>
-    <button data-tooltip="CHEX.HEXEDIT.Delete" type="button" class="fa-solid fa-times chex-delete" data-action="delete"/>
+    <button data-tooltip="CHEX.HEXEDIT.Delete" type="button" class="chex-delete" data-action="delete"/><i class="fa-solid fa-times"></i></button>
 </div>

--- a/templates/frags/chex-forageables.hbs
+++ b/templates/frags/chex-forageables.hbs
@@ -4,5 +4,5 @@
     </select>
     <input type="number" data-tooltip="CHEX.HEXEDIT.Amount" name="forageables.{{id}}.amount" value="{{amount}}">
     <input type="checkbox" data-tooltip="CHEX.HEXEDIT.ShowToPlayersTooltip" name="forageables.{{id}}.show" {{checked show}}>
-    <button data-tooltip="CHEX.HEXEDIT.Delete" type="button" class="fa-solid fa-times chex-delete" data-action="delete"/>
+    <button data-tooltip="CHEX.HEXEDIT.Delete" type="button" class="chex-delete" data-action="delete"/><i class="fa-solid fa-times"></i></button>
 </div>

--- a/templates/frags/chex-improvements.hbs
+++ b/templates/frags/chex-improvements.hbs
@@ -3,5 +3,5 @@
         {{selectOptions improvements selected=key valueAttr="id" labelAttr="label" blank=""}}
     </select>
     <input type="checkbox" data-tooltip="CHEX.HEXEDIT.ShowToPlayersTooltip" name="improvements.{{id}}.show" {{checked show}}>
-    <button data-tooltip="CHEX.HEXEDIT.Delete" type="button" class="fa-solid fa-times chex-delete" data-action="delete"/>
+    <button data-tooltip="CHEX.HEXEDIT.Delete" type="button" class="chex-delete" data-action="delete"/><i class="fa-solid fa-times"></i></button>
 </div>

--- a/templates/frags/chex-resources.hbs
+++ b/templates/frags/chex-resources.hbs
@@ -4,5 +4,5 @@
     </select>
     <input type="number" data-tooltip="CHEX.HEXEDIT.Amount" name="resources.{{id}}.amount" value="{{amount}}">
     <input type="checkbox" data-tooltip="CHEX.HEXEDIT.ShowToPlayersTooltip" name="resources.{{id}}.show" {{checked show}}>
-    <button data-tooltip="CHEX.HEXEDIT.Delete" type="button" class="fa-solid fa-times chex-delete" data-action="delete"/>
+    <button data-tooltip="CHEX.HEXEDIT.Delete" type="button" class="chex-delete" data-action="delete"/><i class="fa-solid fa-times"></i></button>
 </div>


### PR DESCRIPTION
v13 basic compatibility
Updates due to Foundry VTT v13 breaking changes, not v12 compatible:
- Updates to support v13 scene control changes (buttons on left)
- Added a dummy button that doesn't do anything because you have to specify an active control when switching to tools and it will activate immediately, which is undesirable for the existing buttons
- Update to force swapping layers when selecting Chex tools now that scene controls don't do that automatically anymore
- Styling/formatting updates to some buttons in dialog boxes that use FontAwesome characters

Other minor updates:
- Corrected missing "#" in default water hex color code
- Automatically turns on the relevant realm/terrain view when using the palette tools (skipping the swap back to the token layer)
- edit to module.json to point to MeusRex repo

This change:
- Should maintain compatibility with existing maps made from earlier versions of the module (no underlying map data changes)
- Does not migrate to Appv2, so deprecation warnings abound
- Does not address existing performance issues on larger maps (will still hang for the larger view types where hexes have relevant data; mostly obvious on travel/terrain where all hexes have data)